### PR TITLE
Prepare Proof of Concept for Authorizers Lookup

### DIFF
--- a/examples/auth-depth/e2e/fixtures.ts
+++ b/examples/auth-depth/e2e/fixtures.ts
@@ -1,0 +1,24 @@
+import { Connection } from 'typeorm';
+import { executeTruncate } from '../../helpers';
+import { UserEntity } from '../src/user/user.entity';
+import { ResourceAEntity } from '../src/resource-a/resource-a.entity';
+import { ResourceBEntity } from '../src/resource-b/resource-b.entity';
+import { ResourceCEntity } from '../src/resource-c/resource-c.entity';
+
+const tables = ['resource_a', 'resource_b', 'resource_c', 'user'];
+export const truncate = async (connection: Connection): Promise<void> => executeTruncate(connection, tables);
+
+export const refresh = async (connection: Connection): Promise<void> => {
+  await truncate(connection);
+
+  const userRepo = connection.getRepository(UserEntity);
+  const resourceARepo = connection.getRepository(ResourceAEntity);
+  const resourceBRepo = connection.getRepository(ResourceBEntity);
+  const resourceCRepo = connection.getRepository(ResourceCEntity);
+
+  await userRepo.save([{ username: 'nestjs-query', password: '123' }]);
+
+  const resourceA = await resourceARepo.save({});
+  const resourceB = await resourceBRepo.save({ resourceAId: resourceA.id.toString() });
+  await resourceCRepo.save({ resourceBId: resourceB.id.toString() });
+};

--- a/examples/auth-depth/e2e/resource-a.resolver.spec.ts
+++ b/examples/auth-depth/e2e/resource-a.resolver.spec.ts
@@ -1,0 +1,116 @@
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Connection } from 'typeorm';
+import { AppModule } from '../src/app.module';
+import { refresh } from './fixtures';
+import { AuthService } from '../src/auth/auth.service';
+
+describe('Authorizers (auth - e2e)', () => {
+  let app: INestApplication;
+  let jwtToken: string;
+
+  let resourceAAuthorizerSpy: jest.SpyInstance | null = null;
+  let resourceBAuthorizerSpy: jest.SpyInstance | null = null;
+  let resourceCAuthorizerSpy: jest.SpyInstance | null = null;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        transform: true,
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        skipMissingProperties: false,
+        forbidUnknownValues: true,
+      }),
+    );
+
+    await app.init();
+    await refresh(app.get(Connection));
+  });
+
+  beforeEach(async () => {
+    const authService = app.get(AuthService);
+    jwtToken = (await authService.login({ username: 'nestjs-query', id: 1 })).accessToken;
+
+    const ResourceADTOAuthorizer = app.get('ResourceADTOAuthorizer', { strict: false });
+    const ResourceBDTOAuthorizer = app.get('ResourceBDTOAuthorizer', { strict: false });
+    const ResourceCDTOAuthorizer = app.get('ResourceCDTOAuthorizer', { strict: false });
+    resourceAAuthorizerSpy = jest.spyOn(ResourceADTOAuthorizer.authOptions, 'authorize');
+    resourceBAuthorizerSpy = jest.spyOn(ResourceBDTOAuthorizer.authOptions, 'authorize');
+    resourceCAuthorizerSpy = jest.spyOn(ResourceCDTOAuthorizer.authOptions, 'authorize');
+  });
+
+  afterAll(() => refresh(app.get(Connection)));
+
+  describe('Authorizers', () => {
+    it('should call all involved authorizers', () =>
+      request(app.getHttpServer())
+        .post('/graphql')
+        .auth(jwtToken, { type: 'bearer' })
+        .send({
+          operationName: null,
+          variables: {},
+          query: `{
+          resourceA(id: 1) {
+            id
+            resourceBs {
+              edges {
+                node {
+                  id
+                  resourceCs {
+                    edges {
+                      node {
+                        id
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }`,
+        })
+        .expect(200)
+        .then(({ body }) => {
+          expect(body).toEqual({
+            data: {
+              resourceA: {
+                id: '1',
+                resourceBs: {
+                  edges: [
+                    {
+                      node: {
+                        id: '1',
+                        resourceCs: {
+                          edges: [
+                            {
+                              node: {
+                                id: '1',
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          });
+          // TODO: proof what instanced called what authorizer?
+          expect(resourceAAuthorizerSpy).toHaveBeenCalledTimes(1);
+          expect(resourceBAuthorizerSpy).toHaveBeenCalledTimes(1);
+          expect(resourceCAuthorizerSpy).toHaveBeenCalledTimes(1);
+        }));
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+});

--- a/examples/auth-depth/src/app.module.ts
+++ b/examples/auth-depth/src/app.module.ts
@@ -1,0 +1,39 @@
+import { Module } from '@nestjs/common';
+import { GraphQLModule } from '@nestjs/graphql';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { typeormOrmConfig } from '../../helpers';
+import { AuthModule } from './auth/auth.module';
+import { UserModule } from './user/user.module';
+import { ResourceAModule } from './resource-a/resource-a.module';
+import { ResourceBModule } from './resource-b/resource-b.module';
+import { ResourceCModule } from './resource-c/resource-c.module';
+
+interface HeadersContainer {
+  headers?: Record<string, string>;
+}
+interface ContextArgs {
+  req?: HeadersContainer;
+  connection?: { context: HeadersContainer };
+}
+
+@Module({
+  imports: [
+    TypeOrmModule.forRoot(typeormOrmConfig('auth')),
+    GraphQLModule.forRoot({
+      autoSchemaFile: 'schema.gql',
+      installSubscriptionHandlers: true,
+      subscriptions: {
+        'subscriptions-transport-ws': {
+          onConnect: (connectionParams: unknown) => ({ headers: connectionParams }),
+        },
+      },
+      context: ({ req, connection }: ContextArgs) => ({ req: { ...req, ...connection?.context } }),
+    }),
+    AuthModule,
+    UserModule,
+    ResourceAModule,
+    ResourceBModule,
+    ResourceCModule,
+  ],
+})
+export class AppModule {}

--- a/examples/auth-depth/src/auth/auth.constants.ts
+++ b/examples/auth-depth/src/auth/auth.constants.ts
@@ -1,0 +1,3 @@
+export const jwtConstants = {
+  secret: 'nestjs-query-secret!!!',
+};

--- a/examples/auth-depth/src/auth/auth.interfaces.ts
+++ b/examples/auth-depth/src/auth/auth.interfaces.ts
@@ -1,0 +1,13 @@
+import { UserEntity } from '../user/user.entity';
+
+export type AuthenticatedUser = Pick<UserEntity, 'id' | 'username'>;
+export type JwtPayload = {
+  sub: number;
+  username: string;
+};
+
+export type UserContext = {
+  req: {
+    user: AuthenticatedUser;
+  };
+};

--- a/examples/auth-depth/src/auth/auth.module.ts
+++ b/examples/auth-depth/src/auth/auth.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { PassportModule } from '@nestjs/passport';
+import { JwtModule } from '@nestjs/jwt';
+import { AuthService } from './auth.service';
+import { UserModule } from '../user/user.module';
+import { jwtConstants } from './auth.constants';
+import { AuthResolver } from './auth.resolver';
+import { JwtStrategy } from './jwt.strategy';
+
+@Module({
+  imports: [
+    UserModule,
+    PassportModule,
+    JwtModule.register({
+      secret: jwtConstants.secret,
+      signOptions: { expiresIn: '1d' },
+    }),
+  ],
+  providers: [AuthService, AuthResolver, JwtStrategy],
+  exports: [AuthService],
+})
+export class AuthModule {}

--- a/examples/auth-depth/src/auth/auth.resolver.ts
+++ b/examples/auth-depth/src/auth/auth.resolver.ts
@@ -1,0 +1,29 @@
+import { Resolver, Mutation, Args, Query } from '@nestjs/graphql';
+import { UnauthorizedException, UseGuards } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { LoginResponseDto } from './dto/login-response.dto';
+import { LoginInputDTO } from './dto/login-input.dto';
+import { UserDTO } from '../user/user.dto';
+import { JwtAuthGuard } from './jwt-auth.guard';
+import { CurrentUser } from './current-user.decorator';
+import { AuthenticatedUser } from './auth.interfaces';
+
+@Resolver()
+export class AuthResolver {
+  constructor(private authService: AuthService) {}
+
+  @Mutation(() => LoginResponseDto)
+  async login(@Args('input') input: LoginInputDTO): Promise<LoginResponseDto> {
+    const user = await this.authService.validateUser(input.username, input.password);
+    if (!user) {
+      throw new UnauthorizedException();
+    }
+    return this.authService.login(user);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Query(() => UserDTO)
+  me(@CurrentUser() user: AuthenticatedUser): Promise<UserDTO> {
+    return this.authService.currentUser(user);
+  }
+}

--- a/examples/auth-depth/src/auth/auth.service.ts
+++ b/examples/auth-depth/src/auth/auth.service.ts
@@ -1,0 +1,42 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { InjectQueryService, QueryService } from '@nestjs-query/core';
+import { UserEntity } from '../user/user.entity';
+import { LoginResponseDto } from './dto/login-response.dto';
+import { AuthenticatedUser, JwtPayload } from './auth.interfaces';
+import { UserDTO } from '../user/user.dto';
+
+@Injectable()
+export class AuthService {
+  constructor(
+    @InjectQueryService(UserEntity) private usersService: QueryService<UserEntity>,
+    private jwtService: JwtService,
+  ) {}
+
+  async validateUser(username: string, pass: string): Promise<AuthenticatedUser | null> {
+    const [user] = await this.usersService.query({ filter: { username: { eq: username } }, paging: { limit: 1 } });
+    // dont use plain text passwords in production!
+    if (user && user.password === pass) {
+      const { password, ...result } = user;
+      return result;
+    }
+    return null;
+  }
+
+  async currentUser(authUser: AuthenticatedUser): Promise<UserDTO> {
+    try {
+      const user = await this.usersService.getById(authUser.id);
+      return user;
+    } catch (e) {
+      throw new UnauthorizedException();
+    }
+  }
+
+  login(user: AuthenticatedUser): Promise<LoginResponseDto> {
+    const payload: JwtPayload = { username: user.username, sub: user.id };
+    return Promise.resolve({
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      accessToken: this.jwtService.sign(payload),
+    });
+  }
+}

--- a/examples/auth-depth/src/auth/current-user.decorator.ts
+++ b/examples/auth-depth/src/auth/current-user.decorator.ts
@@ -1,0 +1,8 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { GqlExecutionContext } from '@nestjs/graphql';
+import { UserContext } from './auth.interfaces';
+
+export const CurrentUser = createParamDecorator((data: unknown, context: ExecutionContext) => {
+  const ctx = GqlExecutionContext.create(context);
+  return ctx.getContext<UserContext>().req.user;
+});

--- a/examples/auth-depth/src/auth/dto/login-input.dto.ts
+++ b/examples/auth-depth/src/auth/dto/login-input.dto.ts
@@ -1,0 +1,13 @@
+import { Field, InputType } from '@nestjs/graphql';
+import { IsString } from 'class-validator';
+
+@InputType()
+export class LoginInputDTO {
+  @Field()
+  @IsString()
+  username!: string;
+
+  @Field()
+  @IsString()
+  password!: string;
+}

--- a/examples/auth-depth/src/auth/dto/login-response.dto.ts
+++ b/examples/auth-depth/src/auth/dto/login-response.dto.ts
@@ -1,0 +1,7 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType('LoginResponse')
+export class LoginResponseDto {
+  @Field()
+  accessToken!: string;
+}

--- a/examples/auth-depth/src/auth/jwt-auth.guard.ts
+++ b/examples/auth-depth/src/auth/jwt-auth.guard.ts
@@ -1,0 +1,12 @@
+import { Injectable, ExecutionContext } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { GqlExecutionContext } from '@nestjs/graphql';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  getRequest(context: ExecutionContext): unknown {
+    const ctx = GqlExecutionContext.create(context);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return,@typescript-eslint/no-unsafe-member-access
+    return ctx.getContext().req;
+  }
+}

--- a/examples/auth-depth/src/auth/jwt.strategy.ts
+++ b/examples/auth-depth/src/auth/jwt.strategy.ts
@@ -1,0 +1,20 @@
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { PassportStrategy } from '@nestjs/passport';
+import { Injectable } from '@nestjs/common';
+import { jwtConstants } from './auth.constants';
+import { AuthenticatedUser, JwtPayload } from './auth.interfaces';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor() {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: jwtConstants.secret,
+    });
+  }
+
+  validate(payload: JwtPayload): Promise<AuthenticatedUser> {
+    return Promise.resolve({ id: payload.sub, username: payload.username });
+  }
+}

--- a/examples/auth-depth/src/main.ts
+++ b/examples/auth-depth/src/main.ts
@@ -1,0 +1,18 @@
+import { NestFactory } from '@nestjs/core';
+import { ValidationPipe } from '@nestjs/common';
+import { AppModule } from './app.module';
+
+async function bootstrap(): Promise<void> {
+  const app = await NestFactory.create(AppModule);
+
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+    }),
+  );
+
+  await app.listen(3000);
+}
+
+// eslint-disable-next-line no-void
+void bootstrap();

--- a/examples/auth-depth/src/resource-a/resource-a.dto.ts
+++ b/examples/auth-depth/src/resource-a/resource-a.dto.ts
@@ -1,0 +1,16 @@
+import { FilterableField, Authorize, QueryOptions, CursorConnection } from '@nestjs-query/query-graphql';
+import { ObjectType, ID } from '@nestjs/graphql';
+import { ResourceBDTO } from '../resource-b/resource-b.dto';
+
+@ObjectType('ResourceA')
+@QueryOptions({ enableTotalCount: true })
+@Authorize({
+  authorize: () => {
+    return {};
+  },
+})
+@CursorConnection('resourceBs', () => ResourceBDTO, { disableRemove: true })
+export class ResourceADTO {
+  @FilterableField(() => ID)
+  id!: number;
+}

--- a/examples/auth-depth/src/resource-a/resource-a.entity.ts
+++ b/examples/auth-depth/src/resource-a/resource-a.entity.ts
@@ -1,0 +1,11 @@
+import { Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { ResourceBEntity } from '../resource-b/resource-b.entity';
+
+@Entity({ name: 'resource_a' })
+export class ResourceAEntity {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @OneToMany(() => ResourceBEntity, (b) => b.resourceA)
+  resourceBs!: ResourceBEntity[];
+}

--- a/examples/auth-depth/src/resource-a/resource-a.module.ts
+++ b/examples/auth-depth/src/resource-a/resource-a.module.ts
@@ -1,0 +1,24 @@
+import { NestjsQueryGraphQLModule } from '@nestjs-query/query-graphql';
+import { NestjsQueryTypeOrmModule } from '@nestjs-query/query-typeorm';
+import { Module } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { ResourceADTO } from './resource-a.dto';
+import { ResourceAEntity } from './resource-a.entity';
+
+@Module({
+  imports: [
+    NestjsQueryGraphQLModule.forFeature({
+      imports: [NestjsQueryTypeOrmModule.forFeature([ResourceAEntity])],
+      resolvers: [
+        {
+          DTOClass: ResourceADTO,
+          EntityClass: ResourceAEntity,
+          enableAggregate: true,
+          enableSubscriptions: true,
+          guards: [JwtAuthGuard],
+        },
+      ],
+    }),
+  ],
+})
+export class ResourceAModule {}

--- a/examples/auth-depth/src/resource-b/resource-b.dto.ts
+++ b/examples/auth-depth/src/resource-b/resource-b.dto.ts
@@ -1,0 +1,16 @@
+import { FilterableField, Authorize, QueryOptions, CursorConnection } from '@nestjs-query/query-graphql';
+import { ObjectType, ID } from '@nestjs/graphql';
+import { ResourceCDTO } from '../resource-c/resource-c.dto';
+
+@ObjectType('ResourceB')
+@QueryOptions({ enableTotalCount: true })
+@Authorize({
+  authorize: () => {
+    return {};
+  },
+})
+@CursorConnection('resourceCs', () => ResourceCDTO, { disableRemove: true })
+export class ResourceBDTO {
+  @FilterableField(() => ID)
+  id!: number;
+}

--- a/examples/auth-depth/src/resource-b/resource-b.entity.ts
+++ b/examples/auth-depth/src/resource-b/resource-b.entity.ts
@@ -1,0 +1,22 @@
+import { Column, Entity, JoinColumn, ManyToOne, ObjectType, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { ResourceAEntity } from '../resource-a/resource-a.entity';
+import { ResourceCEntity } from '../resource-c/resource-c.entity';
+
+@Entity({ name: 'resource_b' })
+export class ResourceBEntity {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ nullable: false, name: 'resource_a_id' })
+  resourceAId!: string;
+
+  @ManyToOne((): ObjectType<ResourceAEntity> => ResourceAEntity, (a) => a.resourceBs, {
+    onDelete: 'CASCADE',
+    nullable: false,
+  })
+  @JoinColumn({ name: 'resource_a_id' })
+  resourceA!: ResourceAEntity;
+
+  @OneToMany(() => ResourceCEntity, (c) => c.resourceB)
+  resourceCs!: ResourceCEntity[];
+}

--- a/examples/auth-depth/src/resource-b/resource-b.module.ts
+++ b/examples/auth-depth/src/resource-b/resource-b.module.ts
@@ -1,0 +1,24 @@
+import { NestjsQueryGraphQLModule } from '@nestjs-query/query-graphql';
+import { NestjsQueryTypeOrmModule } from '@nestjs-query/query-typeorm';
+import { Module } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { ResourceBDTO } from './resource-b.dto';
+import { ResourceBEntity } from './resource-b.entity';
+
+@Module({
+  imports: [
+    NestjsQueryGraphQLModule.forFeature({
+      imports: [NestjsQueryTypeOrmModule.forFeature([ResourceBEntity])],
+      resolvers: [
+        {
+          DTOClass: ResourceBDTO,
+          EntityClass: ResourceBEntity,
+          enableAggregate: true,
+          enableSubscriptions: true,
+          guards: [JwtAuthGuard],
+        },
+      ],
+    }),
+  ],
+})
+export class ResourceBModule {}

--- a/examples/auth-depth/src/resource-c/resource-c.dto.ts
+++ b/examples/auth-depth/src/resource-c/resource-c.dto.ts
@@ -1,0 +1,14 @@
+import { FilterableField, Authorize, QueryOptions } from '@nestjs-query/query-graphql';
+import { ObjectType, ID } from '@nestjs/graphql';
+
+@ObjectType('ResourceC')
+@QueryOptions({ enableTotalCount: true })
+@Authorize({
+  authorize: () => {
+    return {};
+  },
+})
+export class ResourceCDTO {
+  @FilterableField(() => ID)
+  id!: number;
+}

--- a/examples/auth-depth/src/resource-c/resource-c.entity.ts
+++ b/examples/auth-depth/src/resource-c/resource-c.entity.ts
@@ -1,0 +1,18 @@
+import { Column, Entity, JoinColumn, ManyToOne, ObjectType, PrimaryGeneratedColumn } from 'typeorm';
+import { ResourceBEntity } from '../resource-b/resource-b.entity';
+
+@Entity({ name: 'resource_c' })
+export class ResourceCEntity {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ nullable: false, name: 'resource_b_id' })
+  resourceBId!: string;
+
+  @ManyToOne((): ObjectType<ResourceBEntity> => ResourceBEntity, (b) => b.resourceCs, {
+    onDelete: 'CASCADE',
+    nullable: false,
+  })
+  @JoinColumn({ name: 'resource_b_id' })
+  resourceB!: ResourceBEntity;
+}

--- a/examples/auth-depth/src/resource-c/resource-c.module.ts
+++ b/examples/auth-depth/src/resource-c/resource-c.module.ts
@@ -1,0 +1,24 @@
+import { NestjsQueryGraphQLModule } from '@nestjs-query/query-graphql';
+import { NestjsQueryTypeOrmModule } from '@nestjs-query/query-typeorm';
+import { Module } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { ResourceCDTO } from './resource-c.dto';
+import { ResourceCEntity } from './resource-c.entity';
+
+@Module({
+  imports: [
+    NestjsQueryGraphQLModule.forFeature({
+      imports: [NestjsQueryTypeOrmModule.forFeature([ResourceCEntity])],
+      resolvers: [
+        {
+          DTOClass: ResourceCDTO,
+          EntityClass: ResourceCEntity,
+          enableAggregate: true,
+          enableSubscriptions: true,
+          guards: [JwtAuthGuard],
+        },
+      ],
+    }),
+  ],
+})
+export class ResourceCModule {}

--- a/examples/auth-depth/src/user/user.dto.ts
+++ b/examples/auth-depth/src/user/user.dto.ts
@@ -1,0 +1,17 @@
+import { ObjectType, GraphQLISODateTime } from '@nestjs/graphql';
+import { FilterableField } from '@nestjs-query/query-graphql';
+
+@ObjectType('User')
+export class UserDTO {
+  @FilterableField()
+  id!: number;
+
+  @FilterableField()
+  username!: string;
+
+  @FilterableField(() => GraphQLISODateTime)
+  created!: Date;
+
+  @FilterableField(() => GraphQLISODateTime)
+  updated!: Date;
+}

--- a/examples/auth-depth/src/user/user.entity.ts
+++ b/examples/auth-depth/src/user/user.entity.ts
@@ -1,0 +1,19 @@
+import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity({ name: 'user' })
+export class UserEntity {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column()
+  username!: string;
+
+  @Column({ nullable: true })
+  password?: string;
+
+  @CreateDateColumn()
+  created!: Date;
+
+  @UpdateDateColumn()
+  updated!: Date;
+}

--- a/examples/auth-depth/src/user/user.module.ts
+++ b/examples/auth-depth/src/user/user.module.ts
@@ -1,0 +1,9 @@
+import { NestjsQueryTypeOrmModule } from '@nestjs-query/query-typeorm';
+import { Module } from '@nestjs/common';
+import { UserEntity } from './user.entity';
+
+@Module({
+  imports: [NestjsQueryTypeOrmModule.forFeature([UserEntity])],
+  exports: [NestjsQueryTypeOrmModule.forFeature([UserEntity])],
+})
+export class UserModule {}


### PR DESCRIPTION
# Showcase Example

As reported in https://github.com/doug-martin/nestjs-query/issues/1344, I've stumbled upon an unexpected behavior of how Authorizers are called in a GraphQL query while working on a bigger repo using `nestjs-query`.

As discussed, I've prepared an example that uses "multi-level relations" one GraphQL query.

The Entities and DTOs build up relations similarly as described [here](https://github.com/doug-martin/nestjs-query/issues/1344#issuecomment-932077111).

```js
// ------- Resource A

@Authorize({
  authorize: () => {
    return {}
  }
})
@CursorConnection('ResourceB', () => ResourceBDto)
class ResourceADto {
  id: ...
}


// ------- Resource B

@Authorize({
  authorize: () => {
    return {}
  }
})
@CursorConnection('ResourceC', () => ResourceCDto)
class ResourceBDto {
  id: ...
}


// ------- Resource C

@Authorize({
  authorize: () => {
    return {}
  }
})
class ResourceCDto {
  id: ...
}
```

It doesn't really matter that the authorizers just return an empty object (and effectively not "testing"/"authorizing" anything).

## The point of this example is simply to prove and ask

"_In a GraphQL Query requesting 3 different resources _(Resource A -> Resource B -> Resource C)_, are all Authorizers of all the involved DTOs correctly called?_"

- [Test Case](https://github.com/lukasender/nestjs-query/pull/1/files#diff-000749d291e38cb92ea770659f63cfb627dca85d382c3c0b2ad2bc148d5ea8faR60-R76) - A query requesting resources from at least 3 "levels" _(Resource A -> Resource B -> Resource C)_.
- [Expectation](https://github.com/lukasender/nestjs-query/pull/1/files#diff-000749d291e38cb92ea770659f63cfb627dca85d382c3c0b2ad2bc148d5ea8faR106-R109) - all authorizers are called.

## Reproduce

```bash
# setup
git clone https://github.com/lukasender/nestjs-query.git
cd nestjs-query
git checkout lukasender/authorizer-example
npm install
npm run bootstrap

# in one terminal - setup database
cd examples
docker-compose -p nestjs-query-clone up

# in another terminal
cd nestjs-query
npm run test:e2e examples/auth-depth/e2e/resource-a.resolver.spec.ts
```

You'll notice that the last expectation of the test case will fail

![image](https://user-images.githubusercontent.com/1180239/135986525-37ce78b6-eee4-4395-abd3-c23fac27d29e.png)
